### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,8 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+#Rstudio
+*.creds
+.RData
+.Rhistory


### PR DESCRIPTION
Updated to ignore .creds for storing API access credentials and separating these credentials out from the R scripts and markdowns.